### PR TITLE
Use temporary files

### DIFF
--- a/report_spam.workflow
+++ b/report_spam.workflow
@@ -1,27 +1,29 @@
 on run {input, parameters}
-
-        set question to display dialog "Submit as Spam and delete message?" buttons {"Yes!", "No!"} default button 1
-        set answer to button returned of question
-
-         if answer is equal to "No!" then
-                quit
-        end if
-        if answer is equal to "Yes!" then
-        end if
-        tell application "Mail"
-                set theMessages to the selection
-                repeat with thisMessage in theMessages
-                        set thisSource to source of thisMessage as string
-                        tell application "Terminal"
-                                activate
-                                do shell script "curl -F mailContent=" & quoted form of thisSource & " http://spamreport.spamrl.com/spamreport.php"
-                                quit
-                        end tell
-                end repeat
-        end tell
-        tell application "Mail"
-                set theMessages to (get selection)
-                delete theMessages
-        end tell
-        return input
+	
+	set question to display dialog "Report as spam and delete message?" buttons {"Yes", "No"} default button 1
+	set answer to button returned of question
+	
+	if answer is equal to "No" then
+		quit
+	end if
+	
+	tell application "Mail"
+		set theMessages to the selection
+		repeat with thisMessage in theMessages
+			set thisSource to source of thisMessage as string
+			set temporaryFile to POSIX path of (path to temporary items folder) & "spamreport-" & rich text 3 thru -1 of ((random number) as string)
+			try
+				set fileHandle to open for access temporaryFile with write permission
+				write thisSource to fileHandle as «class utf8»
+				close access fileHandle
+			on error
+				try
+					close access temporaryFile
+				end try
+			end try
+			do shell script "curl -X POST -d @" & temporaryFile & " http://spamreport.spamrl.com/spamreport.php"
+			do shell script "rm " & temporaryFile
+			move thisMessage to trash mailbox
+		end repeat
+	end tell
 end run

--- a/report_spam.workflow
+++ b/report_spam.workflow
@@ -1,27 +1,26 @@
-on run {input, parameters}
+set question to display dialog "Report as spam and delete message?" buttons {"Yes", "No"} default button 1
+set answer to button returned of question
 
-        set question to display dialog "Submit as Spam and delete message?" buttons {"Yes!", "No!"} default button 1
-        set answer to button returned of question
+if answer is equal to "No" then
+	quit
+end if
 
-         if answer is equal to "No!" then
-                quit
-        end if
-        if answer is equal to "Yes!" then
-        end if
-        tell application "Mail"
-                set theMessages to the selection
-                repeat with thisMessage in theMessages
-                        set thisSource to source of thisMessage as string
-                        tell application "Terminal"
-                                activate
-                                do shell script "curl -F mailContent=" & quoted form of thisSource & " http://spamreport.spamrl.com/spamreport.php"
-                                quit
-                        end tell
-                end repeat
-        end tell
-        tell application "Mail"
-                set theMessages to (get selection)
-                delete theMessages
-        end tell
-        return input
-end run
+tell application "Mail"
+	set theMessages to the selection
+	repeat with thisMessage in theMessages
+		set thisSource to source of thisMessage as string
+		set temporaryFile to POSIX path of (path to temporary items folder) & "spamreport-" & rich text 3 thru -1 of ((random number) as string)
+		try
+			set fileHandle to open for access temporaryFile with write permission
+			write thisSource to fileHandle as «class utf8»
+			close access fileHandle
+		on error
+			try
+				close access temporaryFile
+			end try
+		end try
+		do shell script "curl -X POST -d @" & temporaryFile & " http://spamreport.spamrl.com/spamreport.php"
+		do shell script "rm " & temporaryFile
+		move thisMessage to trash mailbox
+	end repeat
+end tell

--- a/report_spam.workflow
+++ b/report_spam.workflow
@@ -1,26 +1,27 @@
-set question to display dialog "Report as spam and delete message?" buttons {"Yes", "No"} default button 1
-set answer to button returned of question
+on run {input, parameters}
 
-if answer is equal to "No" then
-	quit
-end if
+        set question to display dialog "Submit as Spam and delete message?" buttons {"Yes!", "No!"} default button 1
+        set answer to button returned of question
 
-tell application "Mail"
-	set theMessages to the selection
-	repeat with thisMessage in theMessages
-		set thisSource to source of thisMessage as string
-		set temporaryFile to POSIX path of (path to temporary items folder) & "spamreport-" & rich text 3 thru -1 of ((random number) as string)
-		try
-			set fileHandle to open for access temporaryFile with write permission
-			write thisSource to fileHandle as «class utf8»
-			close access fileHandle
-		on error
-			try
-				close access temporaryFile
-			end try
-		end try
-		do shell script "curl -X POST -d @" & temporaryFile & " http://spamreport.spamrl.com/spamreport.php"
-		do shell script "rm " & temporaryFile
-		move thisMessage to trash mailbox
-	end repeat
-end tell
+         if answer is equal to "No!" then
+                quit
+        end if
+        if answer is equal to "Yes!" then
+        end if
+        tell application "Mail"
+                set theMessages to the selection
+                repeat with thisMessage in theMessages
+                        set thisSource to source of thisMessage as string
+                        tell application "Terminal"
+                                activate
+                                do shell script "curl -F mailContent=" & quoted form of thisSource & " http://spamreport.spamrl.com/spamreport.php"
+                                quit
+                        end tell
+                end repeat
+        end tell
+        tell application "Mail"
+                set theMessages to (get selection)
+                delete theMessages
+        end tell
+        return input
+end run


### PR DESCRIPTION
If emails are too large, curl returns an error. This patch writes the email out to a temporary file, feeds that file to curl, and then cleans up the temporary file.